### PR TITLE
Rebind pug_html instead of using an arg of the same name

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -47,11 +47,11 @@ function parse() {
   };
 
   const nodes = [
-    Object.assign({}, codeBlockDefaults, { val: 'try { pug_html += function(pug_html){' }),
+    Object.assign({}, codeBlockDefaults, { val: '(function () { var real_pug_html = pug_html; pug_html = ""; try {' }),
     tryBlock,
-    Object.assign({}, codeBlockDefaults, { val: "; return pug_html; }('') } catch (e) {" }),
+    Object.assign({}, codeBlockDefaults, { val: '; real_pug_html += pug_html; } catch (e) { pug_html = ""; ' }),
     catchBlock,
-    Object.assign({}, codeBlockDefaults, { val: ';}' }),
+    Object.assign({}, codeBlockDefaults, { val: '; real_pug_html += pug_html; }; pug_html = real_pug_html; }).call(this)' }),
   ];
 
   if (catchTok) {

--- a/test/acceptance/mixins.pug
+++ b/test/acceptance/mixins.pug
@@ -1,0 +1,16 @@
+mixin workingMixin(x)
+  div.from-mixin= x
+
+mixin brokenMixin(x)
+  div.from-mixin= x.some.thing
+
+try
+  +workingMixin("yeah")
+catch
+  +workingMixin("nope")
+
+try
+  +workingMixin("yeah...")
+  +brokenMixin("nope")
+catch
+  +workingMixin("it works")

--- a/test/acceptance/mixins.pug.expected
+++ b/test/acceptance/mixins.pug.expected
@@ -1,0 +1,1 @@
+<div class="from-mixin">yeah</div><div class="from-mixin">it works</div>


### PR DESCRIPTION
The `function(pug_html)` approach did not work with mixins, since mixins are functions that reference the original pug_html variable from the beginning of template code! Mixins simply returned no output.

This probably needs more testing but seems to work for me.